### PR TITLE
Fix race in MemTable::Unref

### DIFF
--- a/db/memtable.h
+++ b/db/memtable.h
@@ -31,7 +31,7 @@ class MemTable {
   void Unref() {
     uint64_t ref = atomic::increment_64_fullbarrier(&refs_, -1);
     assert(ref >= 0);
-    if (refs_ == 0) {
+    if (ref == 0) {
       delete this;
     }
   }


### PR DESCRIPTION
MemTable::Unref is decrementing the refcount on the MemTable, but after
the decremnt it tests the actual in-memory refcount for 0 rather than
the result returned from the atomic decrement. This means that even if
it doesn't drop the last reference, it can see the result of someone else
dropping the last reference, resulting in a double free.

Signed-off-by: Jeremy Fitzhardinge jeremy@goop.org
